### PR TITLE
[Feature] Configurable TaskMetadata schema

### DIFF
--- a/etc/findbugsExclude.xml
+++ b/etc/findbugsExclude.xml
@@ -23,6 +23,10 @@
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
   </Match>
   <Match>
+    <Class name="io.streamnative.pulsar.recipes.task.TaskWorkerConfiguration$Builder"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
     <Class name="io.streamnative.pulsar.recipes.task.TaskMetadataEvictionListener"/>
     <Bug pattern="SE_BAD_FIELD"/>
   </Match>

--- a/long-running-tasks/src/main/java/io/streamnative/pulsar/recipes/task/MessagingFactory.java
+++ b/long-running-tasks/src/main/java/io/streamnative/pulsar/recipes/task/MessagingFactory.java
@@ -23,7 +23,6 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TableView;
 
 /**
@@ -34,19 +33,18 @@ import org.apache.pulsar.client.api.TableView;
 @RequiredArgsConstructor
 class MessagingFactory<T> {
   private final PulsarClient client;
-  private final Schema<TaskMetadata> metadataSchema;
   private final TaskWorkerConfiguration<T, ?> configuration;
 
   TableView<TaskMetadata> taskMetadataTableView() throws PulsarClientException {
     return client
-        .newTableViewBuilder(metadataSchema)
+        .newTableViewBuilder(configuration.getMetadataSchema())
         .topic(configuration.getMetadataTopic())
         .create();
   }
 
   Producer<TaskMetadata> taskMetadataProducer() throws PulsarClientException {
     return client
-        .newProducer(metadataSchema)
+        .newProducer(configuration.getMetadataSchema())
         .topic(configuration.getMetadataTopic())
         .enableBatching(false)
         .create();
@@ -55,7 +53,7 @@ class MessagingFactory<T> {
   Consumer<TaskMetadata> metadataEvictionConsumer(TaskMetadataEvictionListener evictionListener)
       throws PulsarClientException {
     return client
-        .newConsumer(metadataSchema)
+        .newConsumer(configuration.getMetadataSchema())
         .topic(configuration.getMetadataTopic())
         .subscriptionName(configuration.getSubscription())
         .subscriptionType(Shared)

--- a/long-running-tasks/src/main/java/io/streamnative/pulsar/recipes/task/TaskWorker.java
+++ b/long-running-tasks/src/main/java/io/streamnative/pulsar/recipes/task/TaskWorker.java
@@ -28,7 +28,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.Schema;
 
 /** Responsible for the processing of tasks and management of resulting task metadata. */
 @Slf4j
@@ -44,9 +43,7 @@ public class TaskWorker implements AutoCloseable {
     var executor = newSingleThreadExecutor();
     var clock = systemUTC();
 
-    var stateSchema = Schema.JSON(TaskMetadata.class);
-
-    var factory = new MessagingFactory<>(client, stateSchema, configuration);
+    var factory = new MessagingFactory<>(client, configuration);
     var closeables = new ArrayList<AutoCloseable>();
 
     var metadataProducer = factory.taskMetadataProducer();

--- a/long-running-tasks/src/main/java/io/streamnative/pulsar/recipes/task/TaskWorkerConfiguration.java
+++ b/long-running-tasks/src/main/java/io/streamnative/pulsar/recipes/task/TaskWorkerConfiguration.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.client.api.Schema;
 public class TaskWorkerConfiguration<T, R> {
   private final Schema<T> taskSchema;
   private final Schema<R> resultSchema;
+  private final Schema<TaskMetadata> metadataSchema;
   private final String taskTopic;
   private final String metadataTopic;
   private final String subscription;
@@ -56,6 +57,7 @@ public class TaskWorkerConfiguration<T, R> {
   public static class Builder<T, R> {
     private final Schema<T> taskSchema;
     private final Schema<R> resultSchema;
+    private Schema<TaskMetadata> metadataSchema = Schema.JSON(TaskMetadata.class);
     private String taskTopic;
     private String stateTopic;
     private String subscription;
@@ -65,6 +67,11 @@ public class TaskWorkerConfiguration<T, R> {
     private Duration taskRedeliveryDelay = Duration.ofMinutes(5);
     private Duration retention = Duration.ofDays(1);
     private Duration shutdownTimeout = Duration.ofSeconds(10);
+
+    public Builder<T, R> metadataSchema(@NonNull Schema<TaskMetadata> metadataSchema) {
+      this.metadataSchema = metadataSchema;
+      return this;
+    }
 
     /**
      * The topic that the worker will listen for tasks on.
@@ -202,6 +209,7 @@ public class TaskWorkerConfiguration<T, R> {
       return new TaskWorkerConfiguration<>(
           taskSchema,
           resultSchema,
+          metadataSchema,
           taskTopic,
           stateTopic,
           subscription,

--- a/long-running-tasks/src/test/java/io/streamnative/pulsar/recipes/task/MessagingFactoryTest.java
+++ b/long-running-tasks/src/test/java/io/streamnative/pulsar/recipes/task/MessagingFactoryTest.java
@@ -51,7 +51,7 @@ class MessagingFactoryTest {
 
   @BeforeEach
   void beforeEach() {
-    messagingFactory = new MessagingFactory<>(client, metadataSchema, configuration);
+    messagingFactory = new MessagingFactory<>(client, configuration);
   }
 
   @Test

--- a/long-running-tasks/src/test/java/io/streamnative/pulsar/recipes/task/MessagingFactoryTest.java
+++ b/long-running-tasks/src/test/java/io/streamnative/pulsar/recipes/task/MessagingFactoryTest.java
@@ -43,9 +43,9 @@ class MessagingFactoryTest {
   private final TaskWorkerConfiguration<String, String> configuration =
       TaskWorkerConfiguration.builder(Schema.STRING, Schema.STRING)
           .taskTopic("tasks")
+          .metadataSchema(metadataSchema)
           .subscription("subscription")
           .retention(Duration.ofSeconds(1))
-          //          .expirationRedeliveryDelay(Duration.ofSeconds(1))
           .build();
   private MessagingFactory<String> messagingFactory;
 


### PR DESCRIPTION
### Motivation

Users may wish to decide how task metadata is serialised in the topics to match their own standards of intended usage.

### Modifications

* Allow task metadata schema to be captured by the configuration builder.
* Derive all schema for task metadata from the configuration.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
