### PR TITLE
[feature] [client] Add two compnents to support imprecise priority messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <module>long-running-tasks</module>
     <module>rpc</module>
     <module>test</module>
+    <module>priority-messages</module>
   </modules>
 
   <scm>
@@ -129,6 +130,11 @@
       <dependency>
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-client</artifactId>
+        <version>${pulsar.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pulsar</groupId>
+        <artifactId>pulsar-client-api</artifactId>
         <version>${pulsar.version}</version>
       </dependency>
       <dependency>

--- a/priority-messages/pom.xml
+++ b/priority-messages/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.streamnative</groupId>
+    <artifactId>pulsar-recipes</artifactId>
+    <version>1.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>priority-messages</artifactId>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/priority-messages/pom.xml
+++ b/priority-messages/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2022 StreamNative
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/ConstsForPriorityMessages.java
+++ b/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/ConstsForPriorityMessages.java
@@ -1,0 +1,6 @@
+package io.streamnative.pulsar.recipes.client.priority;
+
+public interface ConstsForPriorityMessages {
+
+    String MSG_PROP_PRIORITY = "sn_msg_prop_priority";
+}

--- a/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/ConstsForPriorityMessages.java
+++ b/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/ConstsForPriorityMessages.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 StreamNative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.recipes.client.priority;
 
 public interface ConstsForPriorityMessages {

--- a/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityConsumerInterceptor.java
+++ b/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityConsumerInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 StreamNative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.recipes.client.priority;
 
 import java.util.Collections;

--- a/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityConsumerInterceptor.java
+++ b/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityConsumerInterceptor.java
@@ -1,0 +1,112 @@
+package io.streamnative.pulsar.recipes.client.priority;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerInterceptor;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.ConsumerImpl;
+import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
+
+/***
+ * Helps to make high-priority messages processed faster, but does not guarantee accuracy.
+ * It calculates the priority of the message through the property {@link ConstsForPriorityMessages#MSG_PROP_PRIORITY}
+ * of messages, marks the priority of each consumer through its first message, and pause the low priority consumer to
+ * make the high priority message to be processed faster.
+ */
+@Slf4j
+public class PriorityConsumerInterceptor <T> implements ConsumerInterceptor<T> {
+
+    private final Set<String> consumerSet = Collections.synchronizedSet(new TreeSet<>());
+
+    /** This collection collects the consumers created by the client for each partition. **/
+    private final Map<Integer, Set<ConsumerImpl<T>>> consumerMapping = Collections.synchronizedMap(new TreeMap<>());
+
+    /**
+     * Calculate the priority of messages by the property {@link ConstsForPriorityMessages#MSG_PROP_PRIORITY}.
+     */
+    private int calculatePriority(Message<T> message) {
+        String priorityString = message.getProperties().get(ConstsForPriorityMessages.MSG_PROP_PRIORITY);
+        // If no property in message, means the lowest priority.
+        if (StringUtils.isBlank(priorityString)) {
+            return Integer.MAX_VALUE;
+        }
+        if (!StringUtils.isNumeric(priorityString)) {
+            log.warn("The priority prop [{}] of message is not a number.", ConstsForPriorityMessages.MSG_PROP_PRIORITY);
+            return Integer.MAX_VALUE;
+        }
+        return Integer.valueOf(priorityString);
+    }
+
+    /**
+     * If the high priority partition has many messages, it suspends receiving messages from the low priority partition.
+     * Note: If some messages with low priority have already been received into the memory, they will be consumed as
+     * high level priority.
+     */
+    private synchronized void triggerPauseOrResume() {
+        if (consumerMapping.size() == 1){
+            return;
+        }
+
+        boolean doPause = false;
+        for (Map.Entry<Integer, Set<ConsumerImpl<T>>> entry : consumerMapping.entrySet()){
+            if (doPause){
+                entry.getValue().forEach(ConsumerImpl::pause);
+                continue;
+            }
+            entry.getValue().forEach(ConsumerImpl::resume);
+            long messageCountInMemory = entry.getValue().stream().map(ConsumerImpl::getTotalIncomingMessages)
+                    .reduce((s1, s2) -> s1 + s2).get();
+            if (messageCountInMemory > 50){
+                doPause = true;
+            }
+        }
+    }
+
+    @Override
+    public Message<T> beforeConsume(Consumer<T> consumer, Message<T> message) {
+        // This method is just used to collect the consumers created by the client for each partition.
+        ConsumerImpl<T> consumerImpl = (ConsumerImpl<T>) consumer;
+        if (consumerSet.contains(consumerImpl.getTopic())){
+            return message;
+        }
+        // Registry consumer.
+        int priority = calculatePriority(message);
+        consumerMapping.computeIfAbsent(priority, i -> Collections.synchronizedSet(new HashSet<>()));
+        consumerMapping.get(priority).add(consumerImpl);
+        consumerSet.add(consumerImpl.getTopic());
+        return message;
+    }
+
+    @Override
+    public void close() {
+        consumerMapping.clear();
+        consumerSet.clear();
+    }
+
+    @Override
+    public void onAcknowledge(Consumer<T> consumer, MessageId messageId, Throwable exception) {
+        triggerPauseOrResume();
+    }
+
+    @Override
+    public void onAcknowledgeCumulative(Consumer<T> consumer, MessageId messageId, Throwable exception) {
+        triggerPauseOrResume();
+    }
+
+    @Override
+    public void onNegativeAcksSend(Consumer<T> consumer, Set<MessageId> messageIds) {
+        triggerPauseOrResume();
+    }
+
+    @Override
+    public void onAckTimeoutSend(Consumer<T> consumer, Set<MessageId> messageIds) {
+        triggerPauseOrResume();
+    }
+}

--- a/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityDefinition.java
+++ b/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityDefinition.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 StreamNative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.recipes.client.priority;
 
 import java.util.ArrayList;

--- a/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityDefinition.java
+++ b/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityDefinition.java
@@ -1,0 +1,81 @@
+package io.streamnative.pulsar.recipes.client.priority;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+/***
+ * Declare the priority of each partition.
+ */
+public class PriorityDefinition {
+
+    /** Which partitions are declared in each priority. **/
+    private final Map<Integer/* priority */, List<Integer>/* partitions */> mapping = new TreeMap<>();
+    @Getter
+    /** The priority of partition which is not defined in {@link #mapping}. **/
+    private final int defaultPriority;
+    /** Total partition count of the topic. **/
+    private final int partitionCount;
+
+    public PriorityDefinition(int partitionCount, int defaultPriority) {
+        this.defaultPriority = defaultPriority;
+        this.partitionCount = partitionCount;
+    }
+
+    public PriorityDefinition(int partitionCount) {
+        this(partitionCount, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Register the priority of partitions, lower is faster.
+     */
+    public void registerPriority(int priority, int...partitions) {
+        for (int p : partitions) {
+            registerPriority(priority, p);
+        }
+    }
+
+    /**
+     * Register the priority of a partition, lower is faster.
+     */
+    public void registerPriority(int priority, int partition) {
+        // If the partition has already registered, remove it.
+        mapping.values().stream().forEach(l -> l.remove((Object) partition));
+        // Put the value.
+        mapping.computeIfAbsent(priority, p -> new ArrayList<>());
+        mapping.get(priority).add(partition);
+        // If there has an empty value, remove it;
+        Iterator<Map.Entry<Integer, List<Integer>>> iterator = mapping.entrySet().iterator();
+        while (iterator.hasNext()) {
+            if (iterator.next().getValue().isEmpty()) {
+                iterator.remove();
+            }
+        }
+    }
+
+    /**
+     * Get partitions that has clearly prioritized.
+     */
+    public List<Integer> getRegisteredPartitions(int priority) {
+        return mapping.get(priority);
+    }
+
+    /**
+     * Calculate the partitions whose priority is not explicitly stated.
+     */
+    public List<Integer> calculateDefaultPriorityPartitions() {
+        List<Integer> partitionsHasPriority = mapping.values().stream()
+                .flatMap(l -> l.stream()).collect(Collectors.toList());
+        List<Integer> defaultPriorityPartitions = new ArrayList<>();
+        for (int i = 0; i < partitionCount; i++){
+            if (!partitionsHasPriority.contains(i)) {
+                defaultPriorityPartitions.add(i);
+            }
+        }
+        return defaultPriorityPartitions;
+    }
+}

--- a/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityMessageRouter.java
+++ b/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityMessageRouter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 StreamNative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.recipes.client.priority;
 
 import static org.apache.pulsar.client.util.MathUtils.signSafeMod;

--- a/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityMessageRouter.java
+++ b/priority-messages/src/main/java/io/streamnative/pulsar/recipes/client/priority/PriorityMessageRouter.java
@@ -1,0 +1,52 @@
+package io.streamnative.pulsar.recipes.client.priority;
+
+import static org.apache.pulsar.client.util.MathUtils.signSafeMod;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageRouter;
+import org.apache.pulsar.client.api.TopicMetadata;
+
+/***
+ * First, the partitions will be marked with different priorities, this router will send the message to the specified
+ * partition according to the rules defined in {@link PriorityDefinition}. It will calculate the priority by the
+ * property {@link ConstsForPriorityMessages#MSG_PROP_PRIORITY} of each message, and if there has no property in the message,
+ * it will use the default priority of {@link PriorityDefinition}.
+ */
+public class PriorityMessageRouter implements MessageRouter {
+
+    private final AtomicInteger roundRobinIndexer = new AtomicInteger();
+
+    private final PriorityDefinition priorityDefinition;
+
+    /** Cache the result of the method "priorityDefinition.calculateDefaultPriorityPartitions()" **/
+    private final List<Integer> defaultPriorityPartitions;
+
+    public PriorityMessageRouter(PriorityDefinition priorityDefinition) {
+        this.priorityDefinition = priorityDefinition;
+        this.defaultPriorityPartitions = priorityDefinition.calculateDefaultPriorityPartitions();
+    }
+
+    @Override
+    public int choosePartition(Message<?> msg, TopicMetadata metadata) {
+        int priority;
+        try {
+            priority = Integer.valueOf(msg.getProperties().get(ConstsForPriorityMessages.MSG_PROP_PRIORITY));
+        } catch (NumberFormatException | NullPointerException ex){
+            priority = priorityDefinition.getDefaultPriority();
+        }
+        List<Integer> registeredPartitions = priorityDefinition.getRegisteredPartitions(priority);
+        if (registeredPartitions != null) {
+            return roundRobinChoosePartition(registeredPartitions);
+        }
+        return roundRobinChoosePartition(defaultPriorityPartitions);
+    }
+
+    private int roundRobinChoosePartition(List<Integer> partitions) {
+        if (partitions.size() == 1){
+            return partitions.get(0);
+        }
+        int index = signSafeMod(roundRobinIndexer.incrementAndGet(), partitions.size());
+        return partitions.get(index);
+    }
+}

--- a/priority-messages/src/test/java/io/streamnative/pulsar/recipes/client/priority/PriorityMessageSample.java
+++ b/priority-messages/src/test/java/io/streamnative/pulsar/recipes/client/priority/PriorityMessageSample.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 StreamNative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.recipes.client.priority;
 
 import java.util.concurrent.TimeUnit;

--- a/priority-messages/src/test/java/io/streamnative/pulsar/recipes/client/priority/PriorityMessageSample.java
+++ b/priority-messages/src/test/java/io/streamnative/pulsar/recipes/client/priority/PriorityMessageSample.java
@@ -1,0 +1,58 @@
+package io.streamnative.pulsar.recipes.client.priority;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+
+public class PriorityMessageSample {
+
+    public static void main(String[] args) throws Exception{
+
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl("pulsar://broker.example.com:6650/").build();
+
+        final String topicName = "persistent://public/default/tp_1";
+        final String subName = "sub_1";
+        final int partitionCountOfTopic = 5;
+
+        // Create a PriorityDefinition to declare the priority of each partition.
+        PriorityDefinition priorityDefinition = new PriorityDefinition(partitionCountOfTopic);
+        // Mark partition [0,1] has high priority.
+        priorityDefinition.registerPriority(0, 0, 1);
+
+        // Create a PriorityMessageRouter, it will send the message to the specified partition according to the rules
+        // defined in PriorityDefinition.
+        PriorityMessageRouter priorityMessageRouter = new PriorityMessageRouter(priorityDefinition);
+
+        // Create a Producer with priorityMessageRouter.
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .messageRouter(priorityMessageRouter)
+                .enableBatching(false)// Highlight: current solution does not support batch sending.
+                .topic(topicName)
+                .create();
+
+        // Send a message with high priority.
+        producer.newMessage().property(ConstsForPriorityMessages.MSG_PROP_PRIORITY, "0")
+                .value("msg with high priority").send();
+
+        // Send a message with the default priority.
+        producer.newMessage().value("msg with default priority").send();
+
+        // Create a PriorityConsumerInterceptor, It helps to make high-priority messages processed faster, but does
+        // not guarantee accuracy.
+        final PriorityConsumerInterceptor priorityConsumerInterceptor = new PriorityConsumerInterceptor<>();
+
+        // Create a consumer with PriorityConsumerInterceptor.
+        Consumer<Integer> consumer = pulsarClient.newConsumer(Schema.INT32)
+                .topic(topicName)
+                .receiverQueueSize(100)
+                .subscriptionName(subName)
+                .intercept(priorityConsumerInterceptor)
+                .subscribe();
+        // Consume messages.
+        Message<Integer> msg = consumer.receive(1, TimeUnit.SECONDS);
+        consumer.acknowledge(msg);
+    }
+}


### PR DESCRIPTION
### Motivation

Requirement where some messages are classified in to high priority and some messages are classified as low priority. They experience very high traffic on low priority messages compare to high priority messages. But we want their consumers to process the high priority messages first than lower priority messages as high priority messages are time sensitive. 

---

### Modifications

Note:
- Batch send is not supported
- The mode `Key_Shared` is not supported.

---

We define multiple partitions of a topic as high-priority and low-priority partitions, which can be defined by `PriorityDefinition`. And Each message is marked with a priority by property `MSG_PROP_PRIORITY` when it is sent.

```java
    /** Which partitions are declared in each priority. **/
    private final Map<Integer/* priority */, List<Integer>/* partitions */> mapping = new TreeMap<>();
    @Getter
    /** The priority of partition which is not defined in {@link #mapping}. **/
    private final int defaultPriority;
    /** Total partition count of the topic. **/
    private final int partitionCount;
```

---

The new component `PriorityMessageRouter` will send the message to the specified partition according to the rules defined in `PriorityDefinition`. It will calculate the priority by the property `MSG_PROP_PRIORITY` of each message, and if there has no property in the message, it will use the default priority.

---

The new component `PriorityConsumerInterceptor` will collect the consumers created by the client for each partition when receiving messages, calculate the priority of the message through the property `MSG_PROP_PRIORITY`, then marks the priority of each consumer through its first message, and pause the low priority consumer to make the high priority message to be processed faster.

Here's how it works: If the high-priority partition has many messages, it suspends receiving messages from the low-priority partition. If some messages with low priority have already been received in the memory, they will be consumed as
high-level priority.

Note: If the priority of a partition is changed, the change takes effect only client restarts after the old messages are consumed.

---

Sample: see `PriorityMessageSample`.

---

### Documentation

Need to update docs?

- [x] `doc-required`
- [ ] `no-need-doc`
- [ ] `doc`

