### PR TITLE
docs: add about SN and license info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/streamnative/pulsar-recipes/actions/workflows/pr-build-and-test.yml/badge.svg)](https://github.com/streamnative/pulsar-recipes/actions/workflows/pr-build-and-test.yml)
 
-A cookbook of varied use-cases built atop of Apache Pulsar. The purpose of this repository is to demonstrate how Apache
+Authored by [StreamNative](https://streamnative.io), this is cookbook of varied use-cases built atop of Apache Pulsar. The purpose of this repository is to demonstrate how Apache
 Pulsar primitives can be combined to produce useful and novel behaviours while benefiting from Pulsar's inherent
 reliability and scalability.
 
@@ -32,4 +32,8 @@ Common build actions:
 
 ## License
 
-Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+This library is licensed under the terms of the [Apache License 2.0](LICENSE) and may include packages written by third parties which carry their own copyright notices and license terms.
+
+### About StreamNative
+
+Founded in 2019 by the original creators of Apache Pulsar, [StreamNative](https://streamnative.io/) is one of the leading contributors to the open-source Apache Pulsar project. We have helped engineering teams worldwide make the move to Pulsar with [StreamNative Cloud](https://streamnative.io/product), a fully managed service to help teams accelerate time-to-production.


### PR DESCRIPTION
Update Readme’s sections: description, license. Add a new "About StreamNative" section

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`
- [ ] `no-need-doc`
- [x] `doc`